### PR TITLE
Add initial WAL implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,8 @@ erl_crash.dump
 
 .tool-versions
 
+.*.wal
+
+.test_wal/*
+
 tags

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,1 @@
 use Mix.Config
-
-config :ex_job, default_concurrency: 10

--- a/lib/ex_job/application/supervisor.ex
+++ b/lib/ex_job/application/supervisor.ex
@@ -1,7 +1,7 @@
 defmodule ExJob.Application.Supervisor do
   use Supervisor
 
-  alias ExJob.Central
+  alias ExJob.{Central, WAL}
 
   def start_link(_args \\ []) do
     Supervisor.start_link(__MODULE__, nil, name: __MODULE__)
@@ -12,6 +12,11 @@ defmodule ExJob.Application.Supervisor do
   end
 
   defp children do
-    [{Central, name: Central}]
+    [
+      {WAL, wal_path()},
+      {Central, name: Central},
+    ]
   end
+
+  defp wal_path, do: Application.get_env(:ex_job, :wal_path, ".ex_job.wal")
 end

--- a/lib/ex_job/pipeline.ex
+++ b/lib/ex_job/pipeline.ex
@@ -16,6 +16,10 @@ defmodule ExJob.Pipeline do
     Supervisor.start_link(__MODULE__, job_module, opts)
   end
 
+  def stop(supervisor, reason \\ :normal) do
+    Supervisor.stop(supervisor, reason)
+  end
+
   def init(job_module) do
     children = children_for(job_module)
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/ex_job/queue.ex
+++ b/lib/ex_job/queue.ex
@@ -6,6 +6,7 @@ defprotocol ExJob.Queue do
   def done(queue, job, result)
   def size(queue)
   def size(queue, state)
+  def working(queue)
 end
 
 defmodule ExJob.Queue.NotWorkingError do

--- a/lib/ex_job/queue/grouped_queue.ex
+++ b/lib/ex_job/queue/grouped_queue.ex
@@ -108,4 +108,8 @@ defimpl ExJob.Queue, for: ExJob.Queue.GroupedQueue do
   def size(grouped_queue = %GroupedQueue{}, :working) do
     Enum.count(grouped_queue.working)
   end
+
+  def working(grouped_queue) do
+    Map.values(grouped_queue.working)
+  end
 end

--- a/lib/ex_job/queue/simple_queue.ex
+++ b/lib/ex_job/queue/simple_queue.ex
@@ -64,4 +64,8 @@ defimpl ExJob.Queue, for: ExJob.Queue.SimpleQueue do
   defp increment(queue, count_type) do
     Map.update!(queue, count_type, &(&1 + 1))
   end
+
+  def working(queue) do
+    Map.values(queue.working)
+  end
 end

--- a/lib/ex_job/wal.ex
+++ b/lib/ex_job/wal.ex
@@ -1,0 +1,109 @@
+defmodule ExJob.WAL do
+  use GenServer
+
+  alias ExJob.{WAL, Queue}
+  alias ExJob.WAL.Events
+
+  def start_link(path, options \\ [name: __MODULE__]) do
+    GenServer.start_link(__MODULE__, path, options)
+  end
+
+  def init(path) do
+    file_mod = Application.get_env(:ex_job, :wal_file_mod, WAL.File)
+    :ok = File.mkdir_p(path)
+    {:ok, %{file_mod: file_mod, path: path, files: %{}}}
+  end
+
+  def append(wal \\ __MODULE__, event) do
+    GenServer.call(wal, {:append, event})
+  end
+
+  def events(wal \\ __MODULE__, job_module) do
+    GenServer.call(wal, {:events, job_module})
+  end
+
+  def read(wal \\ __MODULE__, job_module) do
+    GenServer.call(wal, {:read, job_module})
+  end
+
+  def handle_call({:append, event}, _from, state) do
+    {state, file} = find_or_create_file(state, event)
+    :ok = state.file_mod.append(file, event)
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:events, job_module}, _from, state) do
+    events = read_events(state, job_module)
+    {:reply, {:ok, events}, state}
+  end
+
+  def handle_call({:read, job_module}, _from, state) do
+    {state, _file} = find_or_create_file(state, %{job_module: job_module})
+    events = read_events(state, job_module)
+    queue = apply_events(job_module.new_queue(), events)
+    queue = fail_working_jobs(queue)
+    {:reply, {:ok, queue}, state}
+  end
+
+  defp find_or_create_file(state, event) do
+    file = Map.get(state.files, event.job_module)
+    if file do
+      {state, file}
+    else
+      file = create_file(state, event)
+      state = put_in(state, [:files, event.job_module], file)
+      {state, file}
+    end
+  end
+
+  defp create_file(state, %{job_module: job_module}) do
+    file_path = file_path(state.path, job_module)
+    {:ok, file} = state.file_mod.open(file_path)
+    :ok = state.file_mod.append(file, WAL.Events.FileCreated.new(job_module))
+    file
+  end
+
+  defp file_path(path, job_module) do
+    module_file = job_module |> to_string |> String.replace(".", "") |> Macro.underscore
+    Path.join(path, module_file)
+  end
+
+  defp read_events(state, job_module) do
+    with \
+      {:ok, file} <- Map.fetch(state.files, job_module),
+      {:ok, events} <- state.file_mod.read(file)
+    do
+      events
+    else
+      :error -> []
+      {:error, :enoent} -> []
+    end
+  end
+
+  defp apply_events(queue, events) do
+    Enum.reduce(events, queue, &apply_event(&2, &1))
+  end
+
+  defp apply_event(queue, event) do
+    {:ok, queue} = case event do
+      %Events.FileCreated{} ->
+        {:ok, queue}
+      %Events.JobEnqueued{job: job} ->
+        Queue.enqueue(queue, job)
+      %Events.JobStarted{} ->
+        {:ok, queue, _} = Queue.dequeue(queue)
+        {:ok, queue}
+      %Events.JobDone{state: state, job: job} ->
+        Queue.done(queue, job, state)
+    end
+    queue
+  end
+
+  defp fail_working_jobs(queue) do
+    working_jobs_when_process_failed = Queue.working(queue)
+    Enum.reduce(working_jobs_when_process_failed, queue, fn job, queue ->
+      {:ok, queue} = Queue.done(queue, job, :failure)
+      queue
+    end)
+  end
+end

--- a/lib/ex_job/wal/events.ex
+++ b/lib/ex_job/wal/events.ex
@@ -1,0 +1,33 @@
+defmodule ExJob.WAL.Events do
+  defmodule FileCreated do
+    defstruct [:job_module]
+
+    def new(job_module) when is_atom(job_module) do
+      %__MODULE__{job_module: job_module}
+    end
+  end
+
+  defmodule JobEnqueued do
+    defstruct [:job_module, :job]
+
+    def new(job = %ExJob.Job{}) do
+      %__MODULE__{job_module: job.module, job: job}
+    end
+  end
+
+  defmodule JobStarted do
+    defstruct [:job_module, :job]
+
+    def new(job = %ExJob.Job{}) do
+      %__MODULE__{job_module: job.module, job: job}
+    end
+  end
+
+  defmodule JobDone do
+    defstruct [:job_module, :job, :state]
+
+    def new(job = %ExJob.Job{}, state) when is_atom(state) do
+      %__MODULE__{job_module: job.module, job: job, state: state}
+    end
+  end
+end

--- a/lib/ex_job/wal/file.ex
+++ b/lib/ex_job/wal/file.ex
@@ -1,0 +1,44 @@
+defmodule ExJob.WAL.File do
+  @moduledoc false
+
+  require Logger
+
+  defstruct [:file]
+
+  def open(path) when is_binary(path), do: String.to_charlist(path) |> open
+  def open(path) do
+    Logger.info("Opening WAL file for: #{path}")
+    case :disk_log.open(file: path, name: path) do
+      {:ok, file} -> {:ok, %__MODULE__{file: file}}
+      {:repaired, file, {:recovered, _}, {:badbytes, 0}} -> {:ok, %__MODULE__{file: file}}
+      error -> error
+    end
+  end
+
+  def close(%__MODULE__{file: file}) do
+    :disk_log.close(file)
+  end
+
+  def append(%__MODULE__{file: file}, event) do
+    :disk_log.log(file, event)
+  end
+
+  def read(%__MODULE__{file: file}) do
+    Logger.info("Reading WAL file: #{file}")
+    do_read(file, :start)
+  end
+
+  defp do_read(file, continuation, events \\ [])
+  defp do_read(file, :eof, events) do
+    Logger.info("Read #{Enum.count(events)} events for: #{file}")
+    {:ok, events}
+  end
+  defp do_read(file, continuation, events) do
+    case :disk_log.chunk(file, continuation) do
+      {:error, reason} -> {:error, reason}
+      :eof -> do_read(file, :eof, events)
+      {continuation, new_events} -> do_read(file, continuation, events ++ new_events)
+      {_, _, _bad_bytes} -> {:error, :corrupted_file}
+    end
+  end
+end

--- a/lib/ex_job/wal/in_memory_file.ex
+++ b/lib/ex_job/wal/in_memory_file.ex
@@ -1,0 +1,39 @@
+defmodule ExJob.WAL.InMemoryFile do
+  @moduledoc """
+  In memory storage for the WAL. This implementation is most useful for tests.
+  """
+
+  use GenServer
+
+  defstruct [:pid]
+
+  def open(_path) do
+    {:ok, _pid} = GenServer.start_link(__MODULE__, nil)
+  end
+
+  def init(nil) do
+    {:ok, []}
+  end
+
+  def close(pid) do
+    GenServer.stop(pid)
+  end
+
+  def append(pid, event) do
+    GenServer.call(pid, {:append, event})
+  end
+
+  def read(pid) do
+    GenServer.call(pid, :read)
+  end
+
+  def handle_call({:append, event}, _from, events) do
+    events = [event | events]
+    {:reply, :ok, events}
+  end
+
+  def handle_call(:read, _from, events) do
+    ordered_events = Enum.reverse(events)
+    {:reply, {:ok, ordered_events}, events}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule ExJob.Mixfile do
       app: @app,
       version: @version,
       elixir: "~> 1.5",
+      consolidate_protocols: Mix.env != :test,
       description: "Zero dependency, ultra-fast, background job processing library.",
       package: package(),
       start_permanent: Mix.env == :prod,

--- a/test/ex_job/central_test.exs
+++ b/test/ex_job/central_test.exs
@@ -11,6 +11,12 @@ defmodule ExJob.CentralTest do
     end
   end
 
+  setup do
+    spec = %{id: WAL, start: {GenServer, :start_link, [ExJob.WAL, ".test_wal", [name: ExJob.WAL]]}}
+    {:ok, _} = start_supervised(spec)
+    :ok
+  end
+
   describe "pipeline_for/2" do
     test "starts named pipeline for job if it doesn't exist yet" do
       {:ok, central} = Central.start_link([])

--- a/test/ex_job/wal_test.exs
+++ b/test/ex_job/wal_test.exs
@@ -1,0 +1,139 @@
+defmodule ExJob.WALTest do
+  use ExUnit.Case
+
+  alias ExJob.{WAL, Job, Queue}
+  alias ExJob.WAL.Events
+
+  @wal_path ".test_wal"
+  @default_file_mod Application.get_env(:ex_job, :wal_file_mod)
+
+  defmodule TestJob do
+    use Job
+
+    def perform(_arg), do: :ok
+  end
+
+  defmodule CustomQueueJob do
+    defmodule CustomQueue do
+      defstruct []
+
+      def new do
+        %__MODULE__{}
+      end
+    end
+
+    defimpl ExJob.Queue, for: CustomQueueJob.CustomQueue do
+      def enqueue(_, _), do: {:ok, CustomQueue.new()}
+      def dequeue(_), do: {:ok, CustomQueue.new(), nil}
+      def done(_, _, _), do: {:ok, CustomQueue.new()}
+      def size(_, _ \\ nil), do: 0
+      def working(_), do: []
+    end
+
+    use ExJob.Job
+
+    def perform, do: :ok
+
+    def new_queue, do: CustomQueue.new
+  end
+
+  Enum.map([WAL.File, WAL.InMemoryFile], fn file_mod ->
+    describe "#{file_mod}: append/1" do
+      setup do
+        file_mod = unquote(file_mod)
+        Application.put_env(:ex_job, :wal_file_mod, file_mod)
+        on_exit fn ->
+          Application.put_env(:ex_job, :wal_file_mod, @default_file_mod)
+        end
+        {:ok, wal} = WAL.start_link("#{@wal_path}/#{file_mod}", [])
+        %{wal: wal}
+      end
+
+      test "appends events to WAL", ctx do
+        event = new_event(1)
+        :ok = WAL.append(ctx.wal, event)
+        {:ok, events} = WAL.events(ctx.wal, TestJob)
+        assert ^event = List.last(events)
+      end
+    end
+
+    describe "#{file_mod}: events/1" do
+      setup do
+        {:ok, wal} = WAL.start_link(@wal_path, [])
+        %{wal: wal}
+      end
+
+      test "starts empty", ctx do
+        assert {:ok, []} = WAL.events(ctx.wal, TestJob)
+      end
+
+      test "reads WAL contents", ctx do
+        event1 = new_event(1)
+        event2 = new_event(2)
+        event3 = new_event(3)
+
+        assert :ok = WAL.append(ctx.wal, event1)
+        assert :ok = WAL.append(ctx.wal, event2)
+        assert :ok = WAL.append(ctx.wal, event3)
+
+        {:ok, events} = WAL.events(ctx.wal, TestJob)
+        assert Enum.count(events) == 4
+        assert %Events.FileCreated{} = Enum.at(events, 0)
+        assert Enum.at(events, 1) == event1
+        assert Enum.at(events, 2) == event2
+        assert Enum.at(events, 3) == event3
+      end
+
+      test "resets file pointer", ctx do
+        assert {:ok, []} = WAL.events(ctx.wal, TestJob)
+
+        event1 = new_event(1)
+        :ok = WAL.append(ctx.wal, event1)
+        assert {:ok, [%Events.FileCreated{}, ^event1]} = WAL.events(ctx.wal, TestJob)
+
+        event2 = new_event(2)
+        :ok = WAL.append(ctx.wal, event2)
+        assert {:ok, [%Events.FileCreated{}, ^event1, ^event2]} = WAL.events(ctx.wal, TestJob)
+      end
+    end
+
+    describe "#{file_mod}: read/1" do
+      setup do
+        {:ok, wal} = WAL.start_link(@wal_path, [])
+        %{wal: wal}
+      end
+
+      test "builds an empty queue if no WAL file exists", ctx do
+        {:ok, queue} = WAL.read(ctx.wal, TestJob)
+        assert %ExJob.Queue.SimpleQueue{} = queue
+        assert ExJob.Queue.size(queue) == 0
+      end
+
+      test "builds appropriate queue type", ctx do
+        assert {:ok, %CustomQueueJob.CustomQueue{}} = WAL.read(ctx.wal, CustomQueueJob)
+      end
+
+      test "builds queue from the events in the WAL", ctx do
+        job = new_job(1)
+
+        :ok = WAL.append(ctx.wal, Events.FileCreated.new(TestJob))
+        {:ok, queue} = WAL.read(ctx.wal, TestJob)
+        assert Queue.size(queue) == 0
+
+        :ok = WAL.append(ctx.wal, Events.JobEnqueued.new(job))
+        {:ok, queue} = WAL.read(ctx.wal, TestJob)
+        assert Queue.size(queue, :pending) == 1
+
+        :ok = WAL.append(ctx.wal, Events.JobStarted.new(job))
+        {:ok, queue} = WAL.read(ctx.wal, TestJob)
+        :ok = WAL.append(ctx.wal, Events.JobDone.new(job, :success))
+        assert Queue.size(queue, :working) == 0
+        assert Queue.size(queue) == 0
+      end
+    end
+  end)
+
+  def new_event(arg), do: Events.JobEnqueued.new(new_job(arg))
+
+  def new_job(arg), do: Job.new(TestJob, [arg])
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,5 @@
 Application.put_env(:ex_job, :default_concurrency, 2)
+Application.put_env(:ex_job, :wal_path, ".ex_job.test.wal")
+Application.put_env(:ex_job, :wal_file_mod, ExJob.WAL.InMemoryFile)
 
 ExUnit.start()


### PR DESCRIPTION
Persist jobs to disk. When recovering state, we mark all jobs that were running
as failed - this will change once features to handle job retries are added.

We use Erlang's :disk_log for writing the WAL.