### PR TITLE
Move to one wal per pipeline

### DIFF
--- a/benchmarks/wal_appending_events.exs
+++ b/benchmarks/wal_appending_events.exs
@@ -5,7 +5,7 @@ alias ExJob.WAL
 alias ExJob.WAL.Events
 
 before_fn = fn events ->
-  {:ok, pid} = WAL.start_link(wal_path, name: nil)
+  {:ok, pid} = WAL.start_link(path: wal_path, name: nil)
   {events, pid}
 end
 
@@ -19,20 +19,23 @@ options = [
   after_scenario: after_fn,
   inputs: %{
     "1 event": [Events.QueueSnapshot.new(:some_job, :some_state)],
-    "1000 events": Enum.map(1..1000, fn _ -> Events.QueueSnapshot.new(:some_job, :some_state) end),
-    "10000 events": Enum.map(1..10000, fn _ -> Events.QueueSnapshot.new(:some_job, :some_state) end),
+    "1000 events":
+      Enum.map(1..1000, fn _ -> Events.QueueSnapshot.new(:some_job, :some_state) end),
+    "10000 events":
+      Enum.map(1..10000, fn _ -> Events.QueueSnapshot.new(:some_job, :some_state) end)
   },
-  load: save_path,
+  load: save_path
 ]
 
-options = if match?(["--save"], System.argv) do
-  options ++ [ save: [path: save_path, tag: "master"]]
-else
-  options
-end
+options =
+  if match?(["--save"], System.argv()) do
+    options ++ [save: [path: save_path, tag: "master"]]
+  else
+    options
+  end
 
 benchmark = %{
-  "Appending events": fn ({events, wal}) ->
+  "Appending events": fn {events, wal} ->
     Enum.each(events, fn e -> WAL.append(wal, e) end)
   end
 }

--- a/lib/ex_job/application/supervisor.ex
+++ b/lib/ex_job/application/supervisor.ex
@@ -1,7 +1,7 @@
 defmodule ExJob.Application.Supervisor do
   use Supervisor
 
-  alias ExJob.{Central, WAL}
+  alias ExJob.Central
 
   def start_link(_args \\ []) do
     Supervisor.start_link(__MODULE__, nil, name: __MODULE__)
@@ -13,11 +13,8 @@ defmodule ExJob.Application.Supervisor do
 
   defp children do
     [
-      {WAL, wal_path()},
       {Central, name: Central},
       {Registry, name: ExJob.Registry, keys: :unique}
     ]
   end
-
-  defp wal_path, do: Application.get_env(:ex_job, :wal_path, ".ex_job.wal")
 end

--- a/lib/ex_job/pipeline.ex
+++ b/lib/ex_job/pipeline.ex
@@ -3,39 +3,72 @@ defmodule ExJob.Pipeline do
   A Pipeline represents the workflow for enqueueing and consuming work
   from a single queue.
 
-  Each pipeline can have different queue, worker pool and dequeue strategies.
+  Each pipeline can have different queue, dequeue and worker pool strategies.
   """
 
   use Supervisor
 
+  alias ExJob.WAL
   alias ExJob.Pipeline.{Source, Multiplexer}
 
   def start_link(args \\ []) do
     job_module = Keyword.get(args, :job_module)
     opts = Keyword.get(args, :options, [])
-    Supervisor.start_link(__MODULE__, job_module, opts)
+    wal = Keyword.get(args, :wal)
+    Supervisor.start_link(__MODULE__, {job_module, wal}, opts)
   end
 
   def stop(supervisor, reason \\ :normal) do
     Supervisor.stop(supervisor, reason)
   end
 
-  def init(job_module) do
-    children = children_for(job_module)
+  def init({job_module, wal}) do
+    children = children_for(job_module, wal)
     Supervisor.init(children, strategy: :one_for_one)
   end
 
-  defp children_for(job_module) do
+  def wal(job_module), do: {:ok, wal_name_via(job_module)}
+
+  defp children_for(job_module, nil) do
     [
-      {Source, job_module: job_module, options: [name: source_name_via(job_module)]},
-      {Multiplexer, job_module: job_module, subscribe_to: [source_name_via(job_module)]}
+      wal_spec(job_module),
+      source_spec(job_module),
+      multiplexer_spec(job_module)
     ]
+  end
+
+  defp children_for(job_module, wal) do
+    [
+      source_spec(job_module, wal),
+      multiplexer_spec(job_module)
+    ]
+  end
+
+  defp wal_spec(job_module), do: {WAL, path: wal_path(job_module), name: wal_name_via(job_module)}
+
+  defp source_spec(job_module), do: source_spec(job_module, wal_name_via(job_module))
+
+  defp source_spec(job_module, wal),
+    do: {Source, job_module: job_module, wal: wal, options: [name: source_name_via(job_module)]}
+
+  defp multiplexer_spec(job_module),
+    do: {Multiplexer, job_module: job_module, subscribe_to: [source_name_via(job_module)]}
+
+  defp wal_path(job_module) do
+    wal_dir = Application.get_env(:ex_job, :wal_path, ".ex_job/wal/")
+    module_file = job_module |> to_string |> String.replace(".", "") |> Macro.underscore()
+    Path.join(wal_dir, module_file)
   end
 
   defp source_name_via(job_module),
     do: {:via, Registry, {ExJob.Registry, source_name(job_module)}}
 
   defp source_name(job_module), do: "#{job_module}Source"
+
+  defp wal_name_via(job_module),
+    do: {:via, Registry, {ExJob.Registry, wal_name(job_module)}}
+
+  defp wal_name(job_module), do: "#{job_module}WAL"
 
   def enqueue(supervisor, job) do
     source = source(supervisor)

--- a/lib/ex_job/wal/file.ex
+++ b/lib/ex_job/wal/file.ex
@@ -10,11 +10,20 @@ defmodule ExJob.WAL.File do
   def open(filename) do
     Logger.info("Opening WAL file for: #{filename}")
 
+    ensure_directory_exists!(filename)
+
     case :disk_log.open(file: filename, name: filename) do
       {:ok, file} -> {:ok, %__MODULE__{file: file}}
       {:repaired, file, {:recovered, _}, {:badbytes, 0}} -> {:ok, %__MODULE__{file: file}}
       error -> error
     end
+  end
+
+  defp ensure_directory_exists!(path) do
+    :ok =
+      path
+      |> Path.dirname()
+      |> File.mkdir_p()
   end
 
   def close(%__MODULE__{file: file}) do

--- a/lib/ex_job/wal/state.ex
+++ b/lib/ex_job/wal/state.ex
@@ -5,15 +5,9 @@ defmodule ExJob.WAL.State do
   Restore WAL state from existing in-disk data or initialize and store new state.
   """
   def restore_or_create(path, file_mod: file_mod) do
-    ensure_directory_exists!(path)
-
     build_state(path, file_mod)
     |> open_state_file!
     |> maybe_restore_state
-  end
-
-  defp ensure_directory_exists!(path) do
-    :ok = File.mkdir_p(path)
   end
 
   defp build_state(path, file_mod) when is_binary(path) do

--- a/test/ex_job/wal_test.exs
+++ b/test/ex_job/wal_test.exs
@@ -47,26 +47,26 @@ defmodule ExJob.WALTest do
           Application.put_env(:ex_job, :wal_file_mod, @default_file_mod)
         end)
 
-        {:ok, wal} = WAL.start_link("#{@wal_path}/#{file_mod}", [])
+        {:ok, wal} = WAL.start_link(path: "#{@wal_path}/#{file_mod}", name: nil)
         %{wal: wal}
       end
 
       test "appends events to WAL", ctx do
         event = new_event(1)
         :ok = WAL.append(ctx.wal, event)
-        {:ok, events} = WAL.events(ctx.wal, TestJob)
+        {:ok, events} = WAL.events(ctx.wal)
         assert ^event = List.last(events)
       end
     end
 
     describe "#{file_mod}: events/1" do
       setup do
-        {:ok, wal} = WAL.start_link(@wal_path, [])
+        {:ok, wal} = WAL.start_link(path: @wal_path, name: nil)
         %{wal: wal}
       end
 
       test "starts empty", ctx do
-        assert {:ok, []} = WAL.events(ctx.wal, TestJob)
+        assert {:ok, []} = WAL.events(ctx.wal)
       end
 
       test "reads WAL contents", ctx do
@@ -78,7 +78,7 @@ defmodule ExJob.WALTest do
         assert :ok = WAL.append(ctx.wal, event2)
         assert :ok = WAL.append(ctx.wal, event3)
 
-        {:ok, events} = WAL.events(ctx.wal, TestJob)
+        {:ok, events} = WAL.events(ctx.wal)
         assert Enum.count(events) == 3
         assert Enum.at(events, 0) == event1
         assert Enum.at(events, 1) == event2
@@ -86,21 +86,21 @@ defmodule ExJob.WALTest do
       end
 
       test "resets file pointer", ctx do
-        assert {:ok, []} = WAL.events(ctx.wal, TestJob)
+        assert {:ok, []} = WAL.events(ctx.wal)
 
         event1 = new_event(1)
         :ok = WAL.append(ctx.wal, event1)
-        assert {:ok, [^event1]} = WAL.events(ctx.wal, TestJob)
+        assert {:ok, [^event1]} = WAL.events(ctx.wal)
 
         event2 = new_event(2)
         :ok = WAL.append(ctx.wal, event2)
-        assert {:ok, [^event1, ^event2]} = WAL.events(ctx.wal, TestJob)
+        assert {:ok, [^event1, ^event2]} = WAL.events(ctx.wal)
       end
     end
 
     describe "#{file_mod}: read/1" do
       setup do
-        {:ok, wal} = WAL.start_link(@wal_path, [])
+        {:ok, wal} = WAL.start_link(path: @wal_path, name: nil)
         %{wal: wal}
       end
 

--- a/test/ex_job_test.exs
+++ b/test/ex_job_test.exs
@@ -84,7 +84,8 @@ defmodule ExJobTest do
       defstruct [:job_module]
 
       def perform(return_value) do
-        ExJob.WAL.append(%WALJob{job_module: WALJob})
+        {:ok, wal} = ExJob.Pipeline.wal(__MODULE__)
+        ExJob.WAL.append(wal, %WALJob{job_module: WALJob})
         return_value
       end
     end
@@ -115,7 +116,8 @@ defmodule ExJobTest do
 
     defp wait_for_wal_events(n, timeout \\ 100, elapsed \\ 0) do
       interval = 10
-      {:ok, events} = ExJob.WAL.events(WALJob)
+      {:ok, wal} = ExJob.Pipeline.wal(WALJob)
+      {:ok, events} = ExJob.WAL.events(wal)
       count = Enum.count(events)
 
       if count == n || elapsed > timeout do


### PR DESCRIPTION
Replaces the current global WAL with one WAL per pipeline (job module).

Todo:

- [x] One WAL per pipeline
- [x] Prevent WAL.InMemoryFile from having to create dirs
- [x] Clean up unnecessary complexity on the WAL module now that it doesn't need to support multiple pipelines
- [x] Confirm performance hasn't drop because of call to WAL being inside Source.
- [x] Pipeline.wal/1 should return {:ok, pid}
- [x] Pipeline.source/1 should return {:ok, pid}
