### PR TITLE
FIX/ Grouped Jobs/ New grouped keyed jobs dont crash ExJob

### DIFF
--- a/lib/ex_job/queue/grouped_queue.ex
+++ b/lib/ex_job/queue/grouped_queue.ex
@@ -90,7 +90,8 @@ defimpl ExJob.Queue, for: ExJob.Queue.GroupedQueue do
         grouped_queue
         |> increment(map_result_to_count_key(result))
         |> remove_from_working(job)
-
+	|> cleanup_ages(job.group_by)
+      
       {:ok, grouped_queue}
     else
       raise(ExJob.Queue.NotWorkingError)
@@ -109,6 +110,16 @@ defimpl ExJob.Queue, for: ExJob.Queue.GroupedQueue do
     %GroupedQueue{grouped_queue | working: working}
   end
 
+  defp cleanup_ages(grouped_queue, group) do
+    case grouped_queue.queues[group].pending do
+      {[], []} ->
+	%GroupedQueue{grouped_queue | ages: Map.delete(grouped_queue.ages, group) }
+      _ ->
+	grouped_queue
+    end
+  end
+    
+  
   def size(grouped_queue = %GroupedQueue{}), do: size(grouped_queue, :pending)
 
   def size(grouped_queue = %GroupedQueue{}, :pending) do


### PR DESCRIPTION
ExJob has has the ability to serialize execution of a group of jobs mapped to a particular key.

The ages map is used to select which is the next key to work with. This map is not correctly cleaned up when there are no more pending jobs for a particular key

The result: when a job with a completely new key is added after jobs with another key have been executed, the older key selected, even though there are no pending jobs associated with that key, causing a crash.